### PR TITLE
Add trap for xmlrpc calls

### DIFF
--- a/inc/login.php
+++ b/inc/login.php
@@ -103,6 +103,16 @@ class Simple_Login_Lockdown
         add_action('wp_login_failed', array($this, 'failed_login'));
         add_action('login_init', array($this, 'maybe_kill_login'));
         add_action('wp_login', array($this, 'successful_login'));
+        
+        /*
+         * Hack to also block bad xmlrpc requests. This plugin handles
+         * tracking failed logins from xmlrpc fine but only does blocking
+         * on the login page. This also forces the kill attempt on an
+         * xmlrpc request.
+         */
+        if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+            $this->maybe_kill_login();
+        }
 
         load_plugin_textdomain(
             'simple-login-lockdown',


### PR DESCRIPTION
With the recent rash of brute force attempts against xmlrpc a good simple solution for blocking ips. Simple Login Lockdown is great at tracking invalid logins and blocking users when they pass the failed attempt threshold, however it only accounts for the web based login pages human visitors interact with and completely discounts xmlrpc logins (which are typically automated (apps, Jetpack, etc)).

This pull request adds a simple check and kills the login from xmlrpc if it has surpassed the invalid login threshold.
